### PR TITLE
[Actions] Create new docusaurus version on releases

### DIFF
--- a/.github/workflows/publish_website.yml
+++ b/.github/workflows/publish_website.yml
@@ -32,20 +32,20 @@ jobs:
     #   name: Run Tutorials
     #   run: |
     #     python scripts/run_tutorials.py -w $(pwd)
-    # - if: ${{ inputs.new_version }}
-    #   name: Create new docusaurus version
-    #   run: |
-    #     git config --global user.name "github-actions[bot]"
-    #     git config --global user.email "41898282+github-actions[bot]@users.noreply.github.com"
+    - if: ${{ inputs.new_version }}
+      name: Create new docusaurus version
+      run: |
+        git config --global user.name "github-actions[bot]"
+        git config --global user.email "41898282+github-actions[bot]@users.noreply.github.com"
 
-    #     python3 scripts/convert_ipynb_to_mdx.py --clean
-    #     cd website
-    #     yarn
-    #     yarn docusaurus docs:version ${{ inputs.new_version }}
+        python3 scripts/convert_ipynb_to_mdx.py --clean
+        cd website
+        yarn
+        yarn docusaurus docs:version ${{ inputs.new_version }}
 
-    #     git add --all
-    #     git commit -m "Create version ${{ inputs.new_version }} of site in Docusaurus"
-    #     git push --force origin HEAD:main
+        git add --all
+        git commit -m "Create version ${{ inputs.new_version }} of site in Docusaurus"
+        git push --force origin HEAD:main
     - name: Build website
       run: |
         bash scripts/build_docs.sh -b

--- a/scripts/convert_ipynb_to_mdx.py
+++ b/scripts/convert_ipynb_to_mdx.py
@@ -189,8 +189,9 @@ def create_buttons(
         str: MDX formatted buttons.
     """
     version = get_current_git_tag() or "main"
-    github_url = f"https://github.com/{ORGANIZATION}/{PROJECT}/blob/{version}/tutorials/{nb_metadata['id']}/{nb_metadata['id']}.ipynb"
-    colab_url = f"https://colab.research.google.com/github/{ORGANIZATION}/{PROJECT}/blob/{version}/tutorials/{nb_metadata['id']}/{nb_metadata['id']}.ipynb"
+    github_path = f"{ORGANIZATION}/{PROJECT}/blob/{version}/tutorials/{nb_metadata['id']}/{nb_metadata['id']}.ipynb"
+    github_url = f"https://github.com/{github_path}"
+    colab_url = f"https://colab.research.google.com/github/{github_path}"
     return f'<LinkButtons\n  githubUrl="{github_url}"\n  colabUrl="{colab_url}"\n/>\n\n'
 
 


### PR DESCRIPTION
Converted tutorials are not checked in to version control. We convert them at build time, and on release we need to do this twice:

1. Convert tutorials with buttons pointing to the specific release tag in github. These converted docs are then copied to the `versioned_docs/` directory by docusaurus's versioning mechanism. These versioned converted tutorials **are** checked in to github.
2. Convert tutorials with buttons pointing to the `main` branch. These are for the latest/next unreleased docs and end up in the website build but are **not** checked in to github.

We ensure the unversioned converted docs are not check in using the `.gitignore`.